### PR TITLE
CU-86b4nd2qd - Upgrade Solidus to 4.5

### DIFF
--- a/config/initializers/line_item_controller_gift_card_details.rb
+++ b/config/initializers/line_item_controller_gift_card_details.rb
@@ -2,5 +2,5 @@
 
 Rails.application.config.to_prepare do
   Spree::PermittedAttributes.line_item_attributes << { options: [gift_card_details: [:recipient_name, :recipient_email, :gift_message, :purchaser_name, :send_email_at]] }
-  Spree::Order.line_item_comparison_hooks.add('gift_card_match')
+  Spree::Config.line_item_comparison_hooks << 'gift_card_match'
 end


### PR DESCRIPTION
In Solidus 4.5, there is change in the configuration of `line_item_comparison_hooks`. Previously, this configuration was managed separately, but it has now been moved into `Spree::Config`.
 
The Gift Card gem relies on `line_item_comparison_hooks` for its functionality. Due to this change, we need to use the `Spree::Config` in the Gift Card gem.